### PR TITLE
Fix missing LANGUAGE Entries, CVARs

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -1,5 +1,25 @@
 [enu default]
 
+// Menu Section Headers
+MENU_SPAWNOPTIONS                 = "Spawn Options";
+
+// Menu Static Text
+MENU_PERSISTENCY_TEXT             = "Control whether replacements happen after a mapload:";
+MENU_PERSISTENCYOPTIONS           = "Spawn Persistence Options";
+
+// Menu Option Labels
+MENU_PERSISTENCY                  = "Persistent Spawns: ";
+MENU_RESETPERSISTENCY             = "Reset Persitency: ";
+MENU_RESETWEP                     = "Reset Weapon Options: ";
+MENU_WEPSPAWNRATE                 = "Weapon Spawn Rate: ";
+
+// Menu Options Text
+MENU_STONE_SPAWNTEXT              = "Control the spawn rate of Stones on Chainsaws:";
+MENU_IMPACT_SPAWNTEXT             = "Control the spawn rate of Impact Grenades on Rocket Boxes:";
+MENU_MG13_SPAWNTEXT               = "Control the spawn rate of MG13 Grenades on Chainsaws:";
+MENU_THUNDER_CELLPACK_SPAWNTEXT   = "Control the spawn rate of Thunder Grenades on Cell Packs:";
+MENU_THUNDER_ROCKETBOX_SPAWNTEXT  = "Control the spawn rate of Thunder Grenades on Rocket Boxes:";
+
 // Impact Grenade
 MERCH_CAT_IMPACTGRENADE           = "Melonades";
 MERCH_TAG_IMPACTGRENADE           = "Impact Grenade";

--- a/MENUDEF
+++ b/MENUDEF
@@ -23,17 +23,17 @@ OptionMenu "MelonadesMenu"
 
 	StaticText "$MENU_SPAWNOPTIONS", "Brown"
 	StaticText "$MENU_IMPACT_SPAWNTEXT", "White"
-	Slider "$MENU_WEPSPAWNRATE", "melo_impact_spawn_bias", 0.0, 100, .01, 2
+	Slider "$MENU_WEPSPAWNRATE", "melo_impact_rocketbox_spawn_bias", 0.0, 100, .01, 2
 	SafeCommand "$MENU_RESETWEP", "resetcvar melo_impact_rocketbox_spawn_bias"
 	StaticText ""
 	
 	StaticText "$MENU_MG13_SPAWNTEXT", "White"
-	Slider "$MENU_WEPSPAWNRATE", "melo_mg13_spawn_bias", 0.0, 100, .01, 2
+	Slider "$MENU_WEPSPAWNRATE", "melo_mg13_chainsaw_spawn_bias", 0.0, 100, .01, 2
 	SafeCommand "$MENU_RESETWEP", "resetcvar melo_mg13_chainsaw_spawn_bias"
 	StaticText ""
 	
 	StaticText "$MENU_STONE_SPAWNTEXT", "White"
-	Slider "$MENU_WEPSPAWNRATE", "melo_stone_spawn_bias", 0.0, 100, .01, 2
+	Slider "$MENU_WEPSPAWNRATE", "melo_stone_chainsaw_spawn_bias", 0.0, 100, .01, 2
 	SafeCommand "$MENU_RESETWEP", "resetcvar melo_stone_chainsaw_spawn_bias"
 	StaticText ""
 	
@@ -42,13 +42,13 @@ OptionMenu "MelonadesMenu"
 	SafeCommand "$MENU_RESETWEP", "resetcvar melo_thunder_cellpack_spawn_bias"
 	StaticText "$MENU_THUNDER_ROCKETBOX_SPAWNTEXT", "White"
 	Slider "$MENU_WEPSPAWNRATE", "melo_thunder_rocketbox_spawn_bias", 0.0, 100, .01, 2
-	SafeCommand "$MENU_RESETWEP", "resetcvar melo_thunder_cellpack_spawn_bias"
+	SafeCommand "$MENU_RESETWEP", "resetcvar melo_thunder_rocketbox_spawn_bias"
 	
 	StaticText ""
 	StaticText ""
 
 	StaticText "$MENU_PERSISTENCYOPTIONS", "Brown"
     StaticText "$MENU_PERSISTENCY_TEXT", "White"
-	Option "$MENU_PERSISTENCY", "melo_persistent_spawning", "OnOff"
-	SafeCommand "$MENU_RESETPERSISTENCY", "resetcvar melo_persistent_spawning"
+	Option "$MENU_PERSISTENCY", "melo_persistant_spawning", "OnOff"
+	SafeCommand "$MENU_RESETPERSISTENCY", "resetcvar melo_persistant_spawning"
 }


### PR DESCRIPTION
Apologies, it seems I missed a few entries back when I was copying over some of the Spawn Menu entries from other addons and made several mistakes that never got cleaned up.  I meant to fix them before the HDCoreLib PR was merged but missed that window.  I ran a quick test with the menu and all of the labels are now correct and their sliders line up to the actual CVARs.